### PR TITLE
Record the time that an asset is absorbed

### DIFF
--- a/bin/lib/absorb.js
+++ b/bin/lib/absorb.js
@@ -65,7 +65,8 @@ function getDataFromURL(feedInfo){
 
 				tableData.provider = feedInfo.provider;
 				tableData['provider_name'] = feedInfo['provider_name'];
-
+				tableData['absorb_time'] = new Date() / 1000 | 0;
+				
 				checkFileHasData(audioURL)
 					.then(function(){
 

--- a/bin/lib/extract-items-from-feed.js
+++ b/bin/lib/extract-items-from-feed.js
@@ -62,6 +62,7 @@ module.exports = function(feedURL){
 											enabled : true
 										};
 
+										tableEntry['unix-pubdate'] = Date.parse(tableEntry.pubdate) / 1000 | 0;
 										tableEntry['narrator-id'] = metadata['narrator-id'];
 										tableEntry['is-human'] = metadata['is-human'];
 


### PR DESCRIPTION
And include a unix version of the `pubdate` value for database querying. Used to be stored in Absorber V1, but didn't make it across when we separated 'Absorber' from 'Ingester'