### PR TITLE
Crush the saboteurs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 const dotenv = require('dotenv').config();
 require('./bin/lib/minimum-server');
 
+const interval = process.env.ABSORB_INTERVAL || (1000 * 60) * 2;
 const absorber = require('./bin/lib/absorb.js');
 
-absorber.poll((1000 * 60) * 2, true);
+absorber.poll(interval, true);


### PR DESCRIPTION
`node-fetch` is causing memory leaks when we don't consume the entire body of a request, so it's been replaced by Node's native `http/s` modules.